### PR TITLE
Document MIDI bridge dependencies and platform notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Treat that order as gospel for newcomers: prototype → secure → rehearse → 
 ```bash
 pip install -r software/midi-bridge/requirements.txt
 ```
+   - That bundle pulls in `mido`, `python-rtmidi`, `pyserial`, and `PyYAML`—everything the bridge needs to speak MSP and spin up a virtual MIDI port.
+   - macOS & Linux: the `python-rtmidi` wheels just work; if your distro is grumpy, install ALSA dev headers (`sudo apt install libasound2-dev`) before pip.
+   - Windows: RtMidi can’t conjure virtual ports natively, so pair the bridge with loopMIDI or another virtual bus.
 3) **Run**:
 ```bash
 python3 software/midi-bridge/msp_to_midi.py --serial /dev/ttyUSB0

--- a/docs/CONTROL_STACK_PLAYBOOK.md
+++ b/docs/CONTROL_STACK_PLAYBOOK.md
@@ -22,6 +22,10 @@ This is the soup‑to‑nuts wiring for **flight → MIDI → Rack**.
 ## Single‑drone
 - Config: `config/mapping.yaml`
 - Bridge: `software/midi-bridge/msp_to_midi.py`
+- Deps: `pip install -r software/midi-bridge/requirements.txt`
+  - Installs `mido`, `python-rtmidi`, `pyserial`, and `PyYAML` in one go so the bridge can summon a virtual MIDI port.
+  - macOS & Linux: bundled RtMidi wheels usually behave; if Linux balks, grab ALSA headers first (`sudo apt install libasound2-dev`).
+  - Windows: RtMidi can’t mint virtual outs—patch in loopMIDI or an equivalent bus before launching the bridge.
 
 ## Multi‑drone (per‑channel)
 - Config: `config/multi.yaml` — list each drone: `serial`, `channel`, optional `norm_overrides`

--- a/software/midi-bridge/requirements.txt
+++ b/software/midi-bridge/requirements.txt
@@ -1,0 +1,4 @@
+mido>=1.2
+python-rtmidi>=1.5.6
+pyserial>=3.5
+PyYAML>=6.0


### PR DESCRIPTION
## Summary
- add a requirements.txt for the MIDI bridge so pilots install mido, python-rtmidi, pyserial, and PyYAML together
- document the new requirements file in the README along with platform-specific notes for virtual MIDI support
- mirror the dependency and platform guidance in the control stack playbook to keep the docs in sync

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c3775fb08325acb509c59f3ff7b5