### PR TITLE
Add single-drone MSP bridge CLI and refactor shared pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,27 +43,31 @@ Treat that order as gospel for newcomers: prototype → secure → rehearse → 
 
 * * *
 
-## Quickstart (single‑drone)
-1) **Betaflight**: Angle mode, throttle cap, failsafe; MSP enabled on your USB/UART.  
+## Quickstart (single‑drone bench test)
+1) **Betaflight**: Angle mode, throttle cap, failsafe; MSP enabled on your USB/UART.
 2) **Deps**:
 ```bash
 pip install -r software/midi-bridge/requirements.txt
 ```
-3) **Run**:
+3) **Run the one‑off bridge** (perfect for tuning a fresh quad or rehearsing solo):
 ```bash
 python3 software/midi-bridge/msp_to_midi.py --serial /dev/ttyUSB0
 ```
-This creates a virtual MIDI port **DroneChorus** and streams CCs.
-4) **VCV Rack**: load `vcv/DroneChorus_Patch.vcv`, set the **Core MIDI‑CC** device to **DroneChorus**, CH1.  
-5) **Tune**: scale with attenuverters; adjust slew/curves in `config/mapping.yaml`.
+   - Default MIDI port: a virtual **DroneChorus** device. Override with `--midi-port MyHardware --no-virtual` if you want to hit a physical DIN box.
+   - Reuse the shared scaling map from `config/multi.yaml`; drop a YAML of tweaks via `--norm-overrides path/to/my_overrides.yaml`.
+4) **VCV Rack**: load `vcv/DroneChorus_Patch.vcv`, set the **Core MIDI‑CC** device to **DroneChorus**, Channel 1.
+5) **Fine tune**: ride attenuverters; if you need deeper changes, clone `config/multi.yaml` and point `--norm-config` at your remix.
 
-## Quickstart (multi‑drone, per‑channel)
+## Quickstart (multi‑drone, stage rig)
+This is what you launch when you’re spinning up the full chorus—multiple craft, locked CC maps, each on its own channel.
+
 ```bash
 ./scripts/launch_multi.sh
 ```
-- Edit `config/multi.yaml` (serials, channels).  
-- In Rack: one **MIDI‑CC** per drone, set channel 1..N.  
-- Load `vcv/DroneChorus_2Drones.vcv` as a template.
+- Edit `config/multi.yaml` (serial path per drone, 1‑based channel, optional `norm_overrides`).
+- The launcher spawns one thread per entry, all sharing the same smoothing map.
+- In Rack: instantiate one **MIDI‑CC** per drone and set channels 1..N.
+- Load `vcv/DroneChorus_2Drones.vcv` as a template and keep scaling consistent.
 
 * * *
 

--- a/docs/CONTROL_STACK_PLAYBOOK.md
+++ b/docs/CONTROL_STACK_PLAYBOOK.md
@@ -20,12 +20,13 @@ This is the soup‑to‑nuts wiring for **flight → MIDI → Rack**.
 | 64 | arm     | Global bypass/hold |
 
 ## Single‑drone
-- Config: `config/mapping.yaml`
-- Bridge: `software/midi-bridge/msp_to_midi.py`
+- Use this when you’re flying one whoop or doing bench tuning before stacking channels.
+- Config: reuse the `norm` block in `config/multi.yaml` or supply `--norm-overrides` with a YAML of tweaks.
+- Bridge: `software/midi-bridge/msp_to_midi.py --serial <port>` (defaults to a virtual `DroneChorus` MIDI port, channel 1).
 
 ## Multi‑drone (per‑channel)
 - Config: `config/multi.yaml` — list each drone: `serial`, `channel`, optional `norm_overrides`
-- Bridge: `software/midi-bridge/msp_multi_to_midi.py`
+- Bridge: `software/midi-bridge/msp_multi_to_midi.py` (spawn via `./scripts/launch_multi.sh` when you want all drones live)
 - In Rack, duplicate voice per channel; keep attenuverters modest.
 
 ## Tuning heuristics

--- a/software/midi-bridge/msp_bridge.py
+++ b/software/midi-bridge/msp_bridge.py
@@ -1,0 +1,148 @@
+"""Shared MSP-to-MIDI bridge utilities for Drone Chorus."""
+
+import struct
+import time
+from typing import Dict, Optional
+
+import mido
+import serial
+
+MSP_ATTITUDE = 108
+MSP_RC = 105
+MSP_ANALOG = 110
+
+_STATE_TEMPLATE = {
+    "roll": 0.0,
+    "pitch": 0.0,
+    "yaw": 0.0,
+    "altitude": 0.0,
+    "rssi": 100.0,
+    "vbat": 4.0,
+    "throttle": 1000,
+}
+
+_CC_MAPPING = {
+    "roll": 14,
+    "pitch": 15,
+    "yaw": 16,
+    "altitude": 17,
+    "rssi": 18,
+    "vbat": 19,
+    "throttle": 20,
+}
+
+
+def clamp(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))
+
+
+class Smoother:
+    def __init__(self, slew: float = 0.05) -> None:
+        self._slew = slew
+        self._y: Optional[float] = None
+
+    def step(self, x: float) -> float:
+        if self._y is None:
+            self._y = x
+            return x
+        delta = clamp(x - self._y, -self._slew, self._slew)
+        self._y += delta
+        return self._y
+
+
+class Mapper:
+    def __init__(self, norm: Dict[str, Dict[str, float]]) -> None:
+        self._norm = norm
+        self._smoothers = {
+            key: Smoother(spec.get("slew", 0.03)) for key, spec in norm.items()
+        }
+
+    def norm01(self, key: str, value: float) -> float:
+        spec = self._norm[key]
+        lo, hi = spec["min"], spec["max"]
+        rng = hi - lo
+        v = 0.0 if rng == 0 else (value - lo) / rng
+        v = clamp(v, 0.0, 1.0)
+        if spec.get("curve") == "expo":
+            shaped = (abs(v - 0.5) * 2) ** 1.3
+            shaped *= 1 if v >= 0.5 else -1
+            v = shaped * 0.5 + 0.5
+        return self._smoothers[key].step(v)
+
+
+def read_msp_frame(ser) -> Optional[tuple]:
+    if ser.read(1) != b"$" or ser.read(1) != b"M" or ser.read(1) != b"<":
+        return None
+    size_bytes = ser.read(1)
+    cmd_bytes = ser.read(1)
+    if not size_bytes or not cmd_bytes:
+        return None
+    size = size_bytes[0]
+    cmd = cmd_bytes[0]
+    data = ser.read(size)
+    ser.read(1)  # checksum throwaway
+    return cmd, data
+
+
+def build_mapper(norm: Dict[str, Dict[str, float]], overrides: Optional[Dict] = None) -> Mapper:
+    merged = {key: dict(spec) for key, spec in norm.items()}
+    if overrides:
+        for key, values in overrides.items():
+            merged.setdefault(key, {}).update(values)
+    return Mapper(merged)
+
+
+def update_state_from_msp(state: Dict[str, float], cmd: int, data: bytes) -> None:
+    if cmd == MSP_ATTITUDE and len(data) >= 6:
+        roll, pitch, yaw = struct.unpack("<hhh", data[:6])
+        state["roll"] = roll / 10.0
+        state["pitch"] = pitch / 10.0
+    elif cmd == MSP_RC and len(data) >= 16:
+        channels = struct.unpack("<8H", data[:16])
+        state["throttle"] = channels[2]
+        state["yaw"] = (channels[3] - 1500) / 500.0 * 200.0
+    elif cmd == MSP_ANALOG and len(data) >= 7:
+        state["vbat"] = data[0] / 10.0
+        state["rssi"] = data[3] if len(data) >= 5 else 100
+
+
+def emit_state_cc(midi_out, mapper: Mapper, channel: int, state: Dict[str, float]) -> None:
+    for key, control in _CC_MAPPING.items():
+        value = int(mapper.norm01(key, state[key]) * 127)
+        midi_out.send(
+            mido.Message("control_change", channel=channel, control=control, value=value)
+        )
+    gate = 127 if state["throttle"] > 1050 else 0
+    midi_out.send(
+        mido.Message("control_change", channel=channel, control=64, value=gate)
+    )
+
+
+def run_bridge(
+    serial_port: str,
+    midi_out,
+    norm: Dict[str, Dict[str, float]],
+    *,
+    channel: int = 0,
+    norm_overrides: Optional[Dict] = None,
+    stop_event=None,
+    poll_interval: float = 0.02,
+    idle_sleep: float = 0.001,
+) -> None:
+    mapper = build_mapper(norm, norm_overrides)
+    state = dict(_STATE_TEMPLATE)
+    with serial.Serial(serial_port, 115200, timeout=0.01) as ser:  # type: ignore[name-defined]
+        last_emit = 0.0
+        while True:
+            if stop_event is not None and stop_event.is_set():
+                return
+            frame = read_msp_frame(ser)
+            if frame is None:
+                time.sleep(idle_sleep)
+                continue
+            cmd, data = frame
+            update_state_from_msp(state, cmd, data)
+            now = time.time()
+            if now - last_emit > poll_interval:
+                emit_state_cc(midi_out, mapper, channel, state)
+                last_emit = now

--- a/software/midi-bridge/msp_multi_to_midi.py
+++ b/software/midi-bridge/msp_multi_to_midi.py
@@ -1,64 +1,58 @@
 #!/usr/bin/env python3
-import time, struct, yaml, threading
-import serial, mido
+import threading
+import time
+from typing import Any, Dict
 
-MSP_ATTITUDE = 108
-MSP_RC = 105
-MSP_ANALOG = 110
+import mido
+import yaml
 
-def clamp(x, lo, hi): return max(lo, min(hi, x))
+from msp_bridge import run_bridge
 
-class Smoother:
-    def __init__(self, slew=0.05):
-        self.y = None; self.slew = slew
-    def step(self, x):
-        if self.y is None: self.y = x
-        d = clamp(x - self.y, -self.slew, self.slew); self.y += d; return self.y
 
-class Mapper:
-    def __init__(self, norm): self.norm=norm; self.s={k:Smoother(v.get('slew',0.03)) for k,v in norm.items()}
-    def norm01(self, key, val):
-        n=self.norm[key]; lo,hi=n['min'],n['max']; v=0 if hi==lo else (val-lo)/(hi-lo)
-        v=clamp(v,0,1); 
-        if n.get('curve')=='expo': v = ((abs(v-0.5)*2)**1.3) * (1 if v>=0.5 else -1) * 0.5 + 0.5
-        return self.s[key].step(v)
+def worker(
+    drone: Dict[str, Any],
+    norm: Dict[str, Dict[str, float]],
+    midi_out,
+    stop_event: threading.Event,
+) -> None:
+    run_bridge(
+        drone["serial"],
+        midi_out,
+        norm,
+        channel=drone["channel"] - 1,
+        norm_overrides=drone.get("norm_overrides"),
+        stop_event=stop_event,
+    )
 
-def read_msp_frame(ser):
-    if ser.read(1)!=b'$' or ser.read(1)!=b'M' or ser.read(1)!=b'<': return None,None
-    size=ser.read(1)[0]; cmd=ser.read(1)[0]; data=ser.read(size); _=ser.read(1); return cmd,data
 
-def worker(drone, base_norm, midi_out):
-    norm={k:dict(v) for k,v in base_norm.items()}
-    for k,v in (drone.get('norm_overrides') or {}).items(): norm[k].update(v)
-    M=Mapper(norm); ch=drone['channel']-1
-    state={'roll':0,'pitch':0,'yaw':0,'altitude':0,'rssi':100,'vbat':4.0,'throttle':1000}
-    with serial.Serial(drone['serial'],115200,timeout=0.01) as ser:
-        t0=0
-        while True:
-            cmd,data=read_msp_frame(ser)
-            if cmd is None: time.sleep(0.001); continue
-            if cmd==MSP_ATTITUDE and len(data)>=6:
-                r,p,y=struct.unpack('<hhh',data[:6]); state['roll']=r/10.0; state['pitch']=p/10.0
-            elif cmd==MSP_RC and len(data)>=16:
-                chs=struct.unpack('<8H',data[:16]); state['throttle']=chs[2]; state['yaw']=(chs[3]-1500)/500.0*200.0
-            elif cmd==MSP_ANALOG and len(data)>=7:
-                state['vbat']=data[0]/10.0; state['rssi']=data[3] if len(data)>=5 else 100
-            now=time.time()
-            if now-t0>0.02:
-                for key,cc in [('roll',14),('pitch',15),('yaw',16),('altitude',17),('rssi',18),('vbat',19),('throttle',20)]:
-                    v=int(M.norm01(key,state[key])*127); midi_out.send(mido.Message('control_change',channel=ch,control=cc,value=v))
-                gate=127 if state['throttle']>1050 else 0
-                midi_out.send(mido.Message('control_change',channel=ch,control=64,value=gate)); t0=now
+def main() -> None:
+    with open("config/multi.yaml", "r", encoding="utf-8") as fh:
+        cfg = yaml.safe_load(fh)
 
-def main():
-    cfg=yaml.safe_load(open('config/multi.yaml'))
-    try: out=mido.open_output(cfg['midi']['port_name'],virtual=True)
-    except Exception: out=mido.open_output()
-    threads=[]
-    for d in cfg['drones']:
-        t=threading.Thread(target=worker,args=(d,cfg['norm'],out),daemon=True); t.start(); threads.append(t)
     try:
-        while True: time.sleep(1)
-    except KeyboardInterrupt: pass
+        midi_out = mido.open_output(cfg["midi"]["port_name"], virtual=True)
+    except Exception:
+        midi_out = mido.open_output()
 
-if __name__=='__main__': main()
+    stop_event = threading.Event()
+    threads = []
+    for drone in cfg["drones"]:
+        thread = threading.Thread(
+            target=worker,
+            args=(drone, cfg["norm"], midi_out, stop_event),
+            daemon=True,
+        )
+        thread.start()
+        threads.append(thread)
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        stop_event.set()
+        for thread in threads:
+            thread.join(timeout=0.5)
+
+
+if __name__ == "__main__":
+    main()

--- a/software/midi-bridge/msp_to_midi.py
+++ b/software/midi-bridge/msp_to_midi.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""CLI wrapper for bridging a single MSP serial stream into MIDI CCs."""
+
+import argparse
+import sys
+from typing import Any, Dict, Optional
+
+import mido
+import yaml
+
+from msp_bridge import run_bridge
+
+
+def load_norm(config_path: str, key: Optional[str]) -> Dict[str, Dict[str, float]]:
+    with open(config_path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if key is None:
+        if not isinstance(data, dict):
+            raise ValueError(f"Expected mapping in {config_path} for normalization spec")
+        return data
+    try:
+        norm = data[key]
+    except KeyError as exc:
+        raise ValueError(f"Key '{key}' not found in {config_path}") from exc
+    if not isinstance(norm, dict):
+        raise ValueError(f"Expected mapping at key '{key}' in {config_path}")
+    return norm
+
+
+def load_overrides(path: Optional[str]) -> Optional[Dict[str, Dict[str, float]]]:
+    if not path:
+        return None
+    with open(path, "r", encoding="utf-8") as fh:
+        overrides = yaml.safe_load(fh) or None
+    if overrides is not None and not isinstance(overrides, dict):
+        raise ValueError("Overrides file must contain a mapping of parameters")
+    return overrides
+
+
+def open_midi_output(name: Optional[str], virtual: bool) -> Any:
+    if name:
+        try:
+            return mido.open_output(name, virtual=virtual)
+        except Exception:
+            return mido.open_output()
+    return mido.open_output()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bridge MSP telemetry to MIDI CCs for one craft.")
+    parser.add_argument("--serial", required=True, help="Serial port that exposes MSP telemetry")
+    parser.add_argument("--channel", type=int, default=1, help="1-based MIDI channel to target (default: 1)")
+    parser.add_argument(
+        "--midi-port",
+        default="DroneChorus",
+        help="Name of the MIDI output port to open or create. Defaults to 'DroneChorus'.",
+    )
+    parser.add_argument(
+        "--no-virtual",
+        action="store_true",
+        help="Do not request a virtual MIDI port when creating --midi-port.",
+    )
+    parser.add_argument(
+        "--norm-config",
+        default="config/multi.yaml",
+        help="YAML file containing a 'norm' block to reuse for scaling.",
+    )
+    parser.add_argument(
+        "--norm-key",
+        default="norm",
+        help="Key within --norm-config that holds the normalization spec. Use '-' to treat the file itself as the spec.",
+    )
+    parser.add_argument(
+        "--norm-overrides",
+        help="Path to a YAML file with per-parameter overrides (same shape as multi config norm overrides).",
+    )
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=0.02,
+        help="Seconds between CC bursts (default: 0.02).",
+    )
+    parser.add_argument(
+        "--idle-sleep",
+        type=float,
+        default=0.001,
+        help="Seconds to nap while waiting for MSP frames (default: 0.001).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    norm_key = None if args.norm_key == "-" else args.norm_key
+    norm = load_norm(args.norm_config, norm_key)
+    overrides = load_overrides(args.norm_overrides)
+    midi_out = open_midi_output(args.midi_port, virtual=not args.no_virtual)
+
+    try:
+        run_bridge(
+            args.serial,
+            midi_out,
+            norm,
+            channel=max(0, args.channel - 1),
+            norm_overrides=overrides,
+            poll_interval=args.poll_interval,
+            idle_sleep=args.idle_sleep,
+        )
+    except KeyboardInterrupt:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- extract the MSP parsing, smoothing, and CC emission into a reusable helper module
- add a single-port `msp_to_midi.py` CLI that forwards MSP to MIDI with optional overrides
- refresh the README and control playbook to spell out when to use the single versus multi bridge

## Testing
- python3 -m py_compile software/midi-bridge/msp_bridge.py software/midi-bridge/msp_multi_to_midi.py software/midi-bridge/msp_to_midi.py

------
https://chatgpt.com/codex/tasks/task_e_68e3c372eb6c8325a26149d59d418437