### PR TITLE
Use MSP altitude data with throttle fallback for CC17

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ This creates a virtual MIDI port **DroneChorus** and streams CCs.
 
 * * *
 
+## Telemetry → MIDI map (why the knobs wiggle)
+
+| CC | Signal    | Where we steal it from |
+|---:|---|---|
+| 14 | roll      | `MSP_ATTITUDE` → Betaflight roll (deg) |
+| 15 | pitch     | `MSP_ATTITUDE` → Betaflight pitch (deg) |
+| 16 | yaw rate  | RC yaw channel, scaled around 1500 µs |
+| 17 | altitude  | `MSP_ALTITUDE` baro height (meters); if we go deaf for >1.5 s we fake it from throttle so synth pads don’t flatline |
+| 18 | RSSI      | `MSP_ANALOG` RSSI byte |
+| 19 | VBAT      | `MSP_ANALOG` battery volts / 10 |
+| 20 | throttle  | RC throttle channel (1000–2000 µs) |
+| 64 | arm gate  | Throttle > 1050 µs means “go” |
+
+Treat the table like a live notebook: tweak `config/multi.yaml` to adjust min/max curves when the band (or the wind) demands it.
+
+* * *
+
 ## OBS
 Import `obs/DroneChorus_SceneCollection.json`, then relink: **FPV Capture**, **VCV Rack (Window)**, **Program Audio**. Studio Mode recommended.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ This creates a virtual MIDI port **DroneChorus** and streams CCs.
 | 14 | roll      | `MSP_ATTITUDE` → Betaflight roll (deg) |
 | 15 | pitch     | `MSP_ATTITUDE` → Betaflight pitch (deg) |
 | 16 | yaw rate  | RC yaw channel, scaled around 1500 µs |
-| 17 | altitude  | `MSP_ALTITUDE` baro height (meters); if we go deaf for >1.5 s we fake it from throttle so synth pads don’t flatline |
+| 17 | altitude  | `MSP_ALTITUDE` baro height (meters); if we go deaf for >1.5 s we ease toward a throttle-shaped proxy (scaled by the mapping range) so synth pads don’t flatline |
 | 18 | RSSI      | `MSP_ANALOG` RSSI byte |
 | 19 | VBAT      | `MSP_ANALOG` battery volts / 10 |
 | 20 | throttle  | RC throttle channel (1000–2000 µs) |

--- a/docs/CONTROL_STACK_PLAYBOOK.md
+++ b/docs/CONTROL_STACK_PLAYBOOK.md
@@ -3,7 +3,7 @@
 This is the soup‑to‑nuts wiring for **flight → MIDI → Rack**.
 
 ## Signals (surface‑level map)
-- **MSP telemetry** (roll, pitch, yaw proxy, throttle, RSSI, VBAT, altitude/vel)
+- **MSP telemetry** (roll, pitch, yaw proxy, throttle, RSSI, VBAT, altitude/vel via `MSP_ALTITUDE` when present)
 - **Python bridge** smooths & scales → **MIDI CC** on port `DroneChorus`
 - **VCV Rack** reads CC via **Core > MIDI‑CC** (one per drone or channel)
 
@@ -31,4 +31,4 @@ This is the soup‑to‑nuts wiring for **flight → MIDI → Rack**.
 ## Tuning heuristics
 - **Slew** hides jitter; **expo** on roll/pitch feels musical.
 - Use **yaw rate** for lively micro‑movement; keep delay FB under 0.6.
-- If no baro, map **altitude** to vertical velocity or throttle proxy.
+- Altitude CC rides real baro data (`MSP_ALTITUDE`) when Betaflight serves it; after ~1.5 s of silence we gracefully fall back to a throttle-derived proxy so your synth still breathes even on baro-less whoops.

--- a/docs/CONTROL_STACK_PLAYBOOK.md
+++ b/docs/CONTROL_STACK_PLAYBOOK.md
@@ -31,4 +31,4 @@ This is the soup‑to‑nuts wiring for **flight → MIDI → Rack**.
 ## Tuning heuristics
 - **Slew** hides jitter; **expo** on roll/pitch feels musical.
 - Use **yaw rate** for lively micro‑movement; keep delay FB under 0.6.
-- Altitude CC rides real baro data (`MSP_ALTITUDE`) when Betaflight serves it; after ~1.5 s of silence we gracefully fall back to a throttle-derived proxy so your synth still breathes even on baro-less whoops.
+- Altitude CC rides real baro data (`MSP_ALTITUDE`) when Betaflight serves it; after ~1.5 s of silence we gracefully blend toward a throttle-derived proxy (scaled with the same min/max curve) so your synth still breathes even on baro-less whoops.

--- a/software/midi-bridge/msp_multi_to_midi.py
+++ b/software/midi-bridge/msp_multi_to_midi.py
@@ -4,6 +4,7 @@ import serial, mido
 
 MSP_ATTITUDE = 108
 MSP_RC = 105
+MSP_ALTITUDE = 109
 MSP_ANALOG = 110
 
 def clamp(x, lo, hi): return max(lo, min(hi, x))
@@ -31,7 +32,9 @@ def worker(drone, base_norm, midi_out):
     norm={k:dict(v) for k,v in base_norm.items()}
     for k,v in (drone.get('norm_overrides') or {}).items(): norm[k].update(v)
     M=Mapper(norm); ch=drone['channel']-1
-    state={'roll':0,'pitch':0,'yaw':0,'altitude':0,'rssi':100,'vbat':4.0,'throttle':1000}
+    state={'roll':0,'pitch':0,'yaw':0,'altitude':0.0,'rssi':100,'vbat':4.0,'throttle':1000}
+    altitude_valid=False
+    altitude_last_time=0.0
     with serial.Serial(drone['serial'],115200,timeout=0.01) as ser:
         t0=0
         while True:
@@ -41,9 +44,20 @@ def worker(drone, base_norm, midi_out):
                 r,p,y=struct.unpack('<hhh',data[:6]); state['roll']=r/10.0; state['pitch']=p/10.0
             elif cmd==MSP_RC and len(data)>=16:
                 chs=struct.unpack('<8H',data[:16]); state['throttle']=chs[2]; state['yaw']=(chs[3]-1500)/500.0*200.0
+            elif cmd==MSP_ALTITUDE and len(data)>=6:
+                alt_cm,vario=struct.unpack('<ih',data[:6])
+                state['altitude']=alt_cm/100.0
+                altitude_valid=True
+                altitude_last_time=time.time()
             elif cmd==MSP_ANALOG and len(data)>=7:
                 state['vbat']=data[0]/10.0; state['rssi']=data[3] if len(data)>=5 else 100
             now=time.time()
+            if altitude_valid and now-altitude_last_time>1.5:
+                altitude_valid=False
+            if not altitude_valid:
+                thr_ratio=clamp((state['throttle']-1000)/1000.0,0,1)
+                alt_norm=norm['altitude']
+                state['altitude']=alt_norm['min'] + thr_ratio*(alt_norm['max']-alt_norm['min'])
             if now-t0>0.02:
                 for key,cc in [('roll',14),('pitch',15),('yaw',16),('altitude',17),('rssi',18),('vbat',19),('throttle',20)]:
                     v=int(M.norm01(key,state[key])*127); midi_out.send(mido.Message('control_change',channel=ch,control=cc,value=v))

--- a/software/midi-bridge/msp_multi_to_midi.py
+++ b/software/midi-bridge/msp_multi_to_midi.py
@@ -32,7 +32,8 @@ def worker(drone, base_norm, midi_out):
     norm={k:dict(v) for k,v in base_norm.items()}
     for k,v in (drone.get('norm_overrides') or {}).items(): norm[k].update(v)
     M=Mapper(norm); ch=drone['channel']-1
-    state={'roll':0,'pitch':0,'yaw':0,'altitude':0.0,'rssi':100,'vbat':4.0,'throttle':1000}
+    altitude_range = norm['altitude']
+    state={'roll':0,'pitch':0,'yaw':0,'altitude':altitude_range['min'],'rssi':100,'vbat':4.0,'throttle':1000}
     altitude_valid=False
     altitude_last_time=0.0
     with serial.Serial(drone['serial'],115200,timeout=0.01) as ser:
@@ -56,8 +57,9 @@ def worker(drone, base_norm, midi_out):
                 altitude_valid=False
             if not altitude_valid:
                 thr_ratio=clamp((state['throttle']-1000)/1000.0,0,1)
-                alt_norm=norm['altitude']
-                state['altitude']=alt_norm['min'] + thr_ratio*(alt_norm['max']-alt_norm['min'])
+                target_alt=altitude_range['min'] + thr_ratio*(altitude_range['max']-altitude_range['min'])
+                # lean slowly toward the throttle proxy so the smoother downstream has something to chew on
+                state['altitude'] = state['altitude']*0.7 + target_alt*0.3
             if now-t0>0.02:
                 for key,cc in [('roll',14),('pitch',15),('yaw',16),('altitude',17),('rssi',18),('vbat',19),('throttle',20)]:
                     v=int(M.norm01(key,state[key])*127); midi_out.send(mido.Message('control_change',channel=ch,control=cc,value=v))

--- a/software/midi-bridge/msp_multi_to_midi.py
+++ b/software/midi-bridge/msp_multi_to_midi.py
@@ -1,80 +1,262 @@
 #!/usr/bin/env python3
-import time, struct, yaml, threading
-import serial, mido
+"""Bridge Betaflight MSP telemetry into MIDI CC streams for multiple drones.
+
+This version cleans up the previous quick-and-dirty merge that left a pile of
+inline statements and racey altitude handling.  The altitude logic now lives in
+an explicit helper so we can reason about barometric freshness versus the
+throttle-shaped proxy without juggling globals.  Smoothers keep musical gestures
+alive even when telemetry burps.
+"""
+
+from __future__ import annotations
+
+import struct
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, Mapping, Optional
+
+import mido
+import serial
+import yaml
+
 
 MSP_ATTITUDE = 108
 MSP_RC = 105
 MSP_ALTITUDE = 109
 MSP_ANALOG = 110
 
-def clamp(x, lo, hi): return max(lo, min(hi, x))
+
+def clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
 
 class Smoother:
-    def __init__(self, slew=0.05):
-        self.y = None; self.slew = slew
-    def step(self, x):
-        if self.y is None: self.y = x
-        d = clamp(x - self.y, -self.slew, self.slew); self.y += d; return self.y
+    """Simple slew limiter used across signals to tame zipper noise."""
 
+    def __init__(self, slew: float = 0.05) -> None:
+        self.slew = slew
+        self._value: Optional[float] = None
+
+    def step(self, target: float) -> float:
+        if self._value is None:
+            self._value = target
+            return target
+
+        delta = clamp(target - self._value, -self.slew, self.slew)
+        self._value += delta
+        return self._value
+
+
+@dataclass
 class Mapper:
-    def __init__(self, norm): self.norm=norm; self.s={k:Smoother(v.get('slew',0.03)) for k,v in norm.items()}
-    def norm01(self, key, val):
-        n=self.norm[key]; lo,hi=n['min'],n['max']; v=0 if hi==lo else (val-lo)/(hi-lo)
-        v=clamp(v,0,1); 
-        if n.get('curve')=='expo': v = ((abs(v-0.5)*2)**1.3) * (1 if v>=0.5 else -1) * 0.5 + 0.5
-        return self.s[key].step(v)
+    """Convert raw telemetry values into 0..1 for MIDI CC."""
 
-def read_msp_frame(ser):
-    if ser.read(1)!=b'$' or ser.read(1)!=b'M' or ser.read(1)!=b'<': return None,None
-    size=ser.read(1)[0]; cmd=ser.read(1)[0]; data=ser.read(size); _=ser.read(1); return cmd,data
+    norm: Mapping[str, Mapping[str, float]]
+    _smoothers: Dict[str, Smoother] = field(default_factory=dict)
 
-def worker(drone, base_norm, midi_out):
-    norm={k:dict(v) for k,v in base_norm.items()}
-    for k,v in (drone.get('norm_overrides') or {}).items(): norm[k].update(v)
-    M=Mapper(norm); ch=drone['channel']-1
-    altitude_range = norm['altitude']
-    state={'roll':0,'pitch':0,'yaw':0,'altitude':altitude_range['min'],'rssi':100,'vbat':4.0,'throttle':1000}
-    altitude_valid=False
-    altitude_last_time=0.0
-    with serial.Serial(drone['serial'],115200,timeout=0.01) as ser:
-        t0=0
+    def __post_init__(self) -> None:
+        for key, spec in self.norm.items():
+            slew = float(spec.get("slew", 0.03))
+            self._smoothers[key] = Smoother(slew)
+
+    def norm01(self, key: str, value: float) -> float:
+        spec = self.norm[key]
+        low, high = float(spec["min"]), float(spec["max"])
+        if high == low:
+            normalised = 0.0
+        else:
+            normalised = (value - low) / (high - low)
+
+        normalised = clamp(normalised, 0.0, 1.0)
+
+        if spec.get("curve") == "expo":
+            # A tiny punk-rock curve: more sensitive near the edges without
+            # going into full log-land.
+            shifted = (abs(normalised - 0.5) * 2) ** 1.3
+            normalised = (shifted if normalised >= 0.5 else -shifted) * 0.5 + 0.5
+
+        return self._smoothers[key].step(normalised)
+
+
+class AltitudeTracker:
+    """Blend barometric altitude with a throttle-derived proxy when stale."""
+
+    def __init__(
+        self,
+        *,
+        range_min: float,
+        range_max: float,
+        stale_after: float = 1.5,
+        proxy_blend: float = 0.3,
+    ) -> None:
+        self.range_min = range_min
+        self.range_max = range_max
+        self.stale_after = stale_after
+        self.proxy_blend = proxy_blend
+
+        self._last_baro: Optional[float] = None
+        self._last_baro_timestamp: float = 0.0
+        self._current: float = range_min
+
+    def _throttle_proxy(self, throttle_value: float) -> float:
+        ratio = clamp((throttle_value - 1000.0) / 1000.0, 0.0, 1.0)
+        return self.range_min + ratio * (self.range_max - self.range_min)
+
+    def push_baro(self, altitude_m: float, *, timestamp: float) -> None:
+        self._last_baro = altitude_m
+        self._last_baro_timestamp = timestamp
+        self._current = altitude_m
+
+    def value(self, throttle_value: float, *, timestamp: float) -> float:
+        baro_is_fresh = (
+            self._last_baro is not None
+            and timestamp - self._last_baro_timestamp <= self.stale_after
+        )
+
+        if baro_is_fresh:
+            # Stick to the barometric truth while it's fresh.
+            self._current = self._last_baro  # type: ignore[assignment]
+        else:
+            # Ease toward the throttle proxy so pads stay alive when MSP mutes.
+            proxy = self._throttle_proxy(throttle_value)
+            self._current = (1.0 - self.proxy_blend) * self._current + self.proxy_blend * proxy
+
+        return self._current
+
+
+def read_msp_frame(port: serial.Serial) -> tuple[Optional[int], bytes]:
+    if port.read(1) != b"$" or port.read(1) != b"M" or port.read(1) != b"<":
+        return None, b""
+
+    size = port.read(1)
+    if not size:
+        return None, b""
+
+    payload_len = size[0]
+    cmd = port.read(1)
+    if not cmd:
+        return None, b""
+
+    payload = port.read(payload_len)
+    _checksum = port.read(1)
+    return cmd[0], payload
+
+
+def _iter_cc_map() -> Iterable[tuple[str, int]]:
+    return (
+        ("roll", 14),
+        ("pitch", 15),
+        ("yaw", 16),
+        ("altitude", 17),
+        ("rssi", 18),
+        ("vbat", 19),
+        ("throttle", 20),
+    )
+
+
+def worker(drone_cfg: Mapping[str, object], base_norm: Mapping[str, Mapping[str, float]], midi_out: mido.ports.BaseOutput):
+    norm: Dict[str, Dict[str, float]] = {key: dict(value) for key, value in base_norm.items()}
+    for key, override in (drone_cfg.get("norm_overrides") or {}).items():
+        norm[key].update(override)
+
+    mapper = Mapper(norm)
+    channel = int(drone_cfg["channel"]) - 1
+
+    altitude_spec = norm["altitude"]
+    altitude_tracker = AltitudeTracker(
+        range_min=float(altitude_spec["min"]),
+        range_max=float(altitude_spec["max"]),
+    )
+
+    state = {
+        "roll": 0.0,
+        "pitch": 0.0,
+        "yaw": 0.0,
+        "altitude": altitude_tracker.range_min,
+        "rssi": 100.0,
+        "vbat": 4.0,
+        "throttle": 1000.0,
+    }
+
+    serial_path = str(drone_cfg["serial"])
+    with serial.Serial(serial_path, 115200, timeout=0.01) as port:
+        last_emit = 0.0
+
         while True:
-            cmd,data=read_msp_frame(ser)
-            if cmd is None: time.sleep(0.001); continue
-            if cmd==MSP_ATTITUDE and len(data)>=6:
-                r,p,y=struct.unpack('<hhh',data[:6]); state['roll']=r/10.0; state['pitch']=p/10.0
-            elif cmd==MSP_RC and len(data)>=16:
-                chs=struct.unpack('<8H',data[:16]); state['throttle']=chs[2]; state['yaw']=(chs[3]-1500)/500.0*200.0
-            elif cmd==MSP_ALTITUDE and len(data)>=6:
-                alt_cm,vario=struct.unpack('<ih',data[:6])
-                state['altitude']=alt_cm/100.0
-                altitude_valid=True
-                altitude_last_time=time.time()
-            elif cmd==MSP_ANALOG and len(data)>=7:
-                state['vbat']=data[0]/10.0; state['rssi']=data[3] if len(data)>=5 else 100
-            now=time.time()
-            if altitude_valid and now-altitude_last_time>1.5:
-                altitude_valid=False
-            if not altitude_valid:
-                thr_ratio=clamp((state['throttle']-1000)/1000.0,0,1)
-                target_alt=altitude_range['min'] + thr_ratio*(altitude_range['max']-altitude_range['min'])
-                # lean slowly toward the throttle proxy so the smoother downstream has something to chew on
-                state['altitude'] = state['altitude']*0.7 + target_alt*0.3
-            if now-t0>0.02:
-                for key,cc in [('roll',14),('pitch',15),('yaw',16),('altitude',17),('rssi',18),('vbat',19),('throttle',20)]:
-                    v=int(M.norm01(key,state[key])*127); midi_out.send(mido.Message('control_change',channel=ch,control=cc,value=v))
-                gate=127 if state['throttle']>1050 else 0
-                midi_out.send(mido.Message('control_change',channel=ch,control=64,value=gate)); t0=now
+            cmd, payload = read_msp_frame(port)
+            now = time.time()
 
-def main():
-    cfg=yaml.safe_load(open('config/multi.yaml'))
-    try: out=mido.open_output(cfg['midi']['port_name'],virtual=True)
-    except Exception: out=mido.open_output()
-    threads=[]
-    for d in cfg['drones']:
-        t=threading.Thread(target=worker,args=(d,cfg['norm'],out),daemon=True); t.start(); threads.append(t)
+            if cmd is None:
+                time.sleep(0.001)
+                state["altitude"] = altitude_tracker.value(state["throttle"], timestamp=now)
+                continue
+
+            if cmd == MSP_ATTITUDE and len(payload) >= 6:
+                roll, pitch, _yaw = struct.unpack("<hhh", payload[:6])
+                state["roll"] = roll / 10.0
+                state["pitch"] = pitch / 10.0
+
+            elif cmd == MSP_RC and len(payload) >= 16:
+                channels = struct.unpack("<8H", payload[:16])
+                throttle = float(channels[2])
+                state["throttle"] = throttle
+                yaw_channel = float(channels[3])
+                state["yaw"] = (yaw_channel - 1500.0) / 500.0 * 200.0
+
+            elif cmd == MSP_ALTITUDE and len(payload) >= 6:
+                altitude_cm, _vario = struct.unpack("<ih", payload[:6])
+                altitude_m = altitude_cm / 100.0
+                altitude_tracker.push_baro(altitude_m, timestamp=now)
+                state["altitude"] = altitude_m
+
+            elif cmd == MSP_ANALOG and payload:
+                state["vbat"] = payload[0] / 10.0
+                if len(payload) >= 5:
+                    state["rssi"] = float(payload[3])
+
+            # Even if we just processed a frame we still want the fallback tick
+            state["altitude"] = altitude_tracker.value(state["throttle"], timestamp=now)
+
+            if now - last_emit < 0.02:
+                continue
+
+            for key, cc in _iter_cc_map():
+                cc_value = int(mapper.norm01(key, state[key]) * 127)
+                midi_out.send(
+                    mido.Message("control_change", channel=channel, control=cc, value=cc_value)
+                )
+
+            gate_value = 127 if state["throttle"] > 1050.0 else 0
+            midi_out.send(mido.Message("control_change", channel=channel, control=64, value=gate_value))
+            last_emit = now
+
+
+def main() -> None:
+    with open("config/multi.yaml", "r", encoding="utf-8") as handle:
+        config = yaml.safe_load(handle)
+
     try:
-        while True: time.sleep(1)
-    except KeyboardInterrupt: pass
+        midi_out = mido.open_output(config["midi"]["port_name"], virtual=True)
+    except Exception:
+        midi_out = mido.open_output()
 
-if __name__=='__main__': main()
+    threads = []
+    for drone in config["drones"]:
+        thread = threading.Thread(
+            target=worker,
+            args=(drone, config["norm"], midi_out),
+            daemon=True,
+        )
+        thread.start()
+        threads.append(thread)
+
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- parse MSP_ALTITUDE frames in the multi-drone bridge and publish the height to CC17
- fall back to a throttle-derived estimate when altitude updates stop arriving
- document the telemetry-to-CC map and altitude source in the README and control stack playbook

## Testing
- `python3 -m py_compile software/midi-bridge/msp_multi_to_midi.py`


------
https://chatgpt.com/codex/tasks/task_e_68e3c381525483259f62332d317621f5