### PR TITLE
Document MIDI bridge workflow

### DIFF
--- a/software/midi-bridge/README.md
+++ b/software/midi-bridge/README.md
@@ -1,0 +1,39 @@
+# MSP → MIDI Bridge Studio Notes
+
+Welcome to the synth-nerd pit crew. This folder contains the Python that turns
+Betaflight telemetry into modulation you can actually jam with. Treat this as a
+combo lab notebook and zine—the goal is to help you *understand* the flow so you
+can mangle it into your own rig.
+
+## Files at a glance
+
+| File | What it does | Why you should peek |
+| --- | --- | --- |
+| `msp_bridge.py` | Core plumbing: reads MSP frames, smooths/normalizes values, and blasts MIDI CCs. | The inline comments read like a wiring diagram—start here if you're learning the protocol. |
+| `msp_to_midi.py` | Command-line launcher for a single drone. | Shows how to load the YAML norms, open a MIDI port, and kick the bridge loop. |
+| `msp_multi_to_midi.py` | Threaded launcher for multi-drone ensembles. | Demonstrates sharing one MIDI port while isolating each craft on its own channel. |
+
+## Study guide
+
+1. **Normalization maps live in `config/multi.yaml`.** The scripts load them and
+   optionally merge override files. Copy the block, tweak ranges, and pass your
+   remix via `--norm-overrides` while testing.
+2. **Smoothing is your friend.** `Smoother` in `msp_bridge.py` clamps step size
+   so your CCs glide instead of sputter. Experiment with the `slew` values to
+   feel how the synth responds.
+3. **Gate logic rides on throttle.** When the craft is armed (throttle > 1050),
+   we send CC64 = 127. Patch that into envelopes, VCAs, whatever keeps your
+   patch honest.
+
+## Quick experiments
+
+- **Run a dry rehearsal** by pointing `--serial` at a log playback tool like
+  `socat` piping from a file. The bridge doesn't care where the bytes originate.
+- **Add a new telemetry field** by editing `_STATE_TEMPLATE`, `_CC_MAPPING`, and
+  `update_state_from_msp`. The new CC will appear automatically once you map it
+  in Rack.
+- **Teach the class**: have students clone this repo, annotate their own copies
+  of the YAML, and compare how different scaling curves feel on the same patch.
+
+> Bonus punk tip: keep a notepad next to your controller and jot down the
+> wildest sounds each change summons. Science + noise forever.

--- a/software/midi-bridge/msp_bridge.py
+++ b/software/midi-bridge/msp_bridge.py
@@ -1,4 +1,27 @@
-"""Shared MSP-to-MIDI bridge utilities for Drone Chorus."""
+"""Shared MSP-to-MIDI bridge utilities for Drone Chorus.
+
+This module is the beating heart of the *Drone Chorus* telemetry pipeline. It
+is intentionally written in a "show-your-work" style so that students and
+curious performers can follow the signal chain from the serial wire all the way
+to the MIDI messages that animate their synth patches.
+
+Key ideas worth keeping in mind while reading:
+
+* **MSP (MultiWii Serial Protocol)** is the telemetry dialect spoken by
+  Betaflight and friends. Every MSP packet carries a command identifier and a
+  payload of raw bytes. We sample only the few commands we care about (attitude,
+  RC inputs, analog sensors).
+* **Normalization + smoothing** keeps the MIDI output musical. The `Mapper`
+  applies scaling curves (stored in YAML configs) and the `Smoother` class makes
+  sure sudden jumps get softened into glissandos instead of glitches.
+* **MIDI CC messages** are just controller-change events. Each tracked signal
+  gets assigned a controller number (see `_CC_MAPPING`), and we send those
+  values at a steady cadence while MSP frames roll in.
+
+If you're new to this style of code, start by skimming the module-level
+constants, then read `run_bridge` from top to bottom. Every helper is annotated
+with intent and the data it touches.
+"""
 
 import struct
 import time
@@ -7,10 +30,16 @@ from typing import Dict, Optional
 import mido
 import serial
 
+# -- MSP command identifiers -------------------------------------------------
+# These numeric IDs are defined by the MSP spec. We pull out only the ones we
+# need; think of them as opcodes that label the payload format.
 MSP_ATTITUDE = 108
 MSP_RC = 105
 MSP_ANALOG = 110
 
+# A scratch buffer of the telemetry values we track. Each entry represents the
+# "most recent" version of a sensor reading. The numbers below are safe defaults
+# in case the serial line hasn't delivered anything yet.
 _STATE_TEMPLATE = {
     "roll": 0.0,
     "pitch": 0.0,
@@ -21,6 +50,8 @@ _STATE_TEMPLATE = {
     "throttle": 1000,
 }
 
+# Each telemetry field gets pegged to a MIDI CC number. The specific values are
+# mostly arbitrary, but choosing a contiguous block keeps the Rack patch tidy.
 _CC_MAPPING = {
     "roll": 14,
     "pitch": 15,
@@ -33,16 +64,36 @@ _CC_MAPPING = {
 
 
 def clamp(x: float, lo: float, hi: float) -> float:
+    """Limit ``x`` to the inclusive range ``[lo, hi]``.
+
+    This tiny helper shows up everywhere because both MSP and MIDI have
+    well-defined limits. Without clamping we'd risk sending negative CC values
+    or blowing past the 0-127 MIDI range.
+    """
+
     return max(lo, min(hi, x))
 
 
 class Smoother:
+    """Single-pole slew limiter for taming sudden jumps in controller values.
+
+    Many MSP readings (RSSI, RC sticks) can spike several percentage points
+    between frames. Feeding that straight into MIDI would produce zipper noise.
+    The smoother stores the last output value and walks toward the new value at
+    a fixed rate (the ``slew`` parameter).
+    """
+
     def __init__(self, slew: float = 0.05) -> None:
+        # ``slew`` is the maximum amount we allow the output to move per update
+        # step. Smaller numbers => slower, more graceful movements.
         self._slew = slew
         self._y: Optional[float] = None
 
     def step(self, x: float) -> float:
+        """Push a new reading through the filter and return the smoothed value."""
+
         if self._y is None:
+            # Bootstrap: the first sample simply sets the initial state.
             self._y = x
             return x
         delta = clamp(x - self._y, -self._slew, self._slew)
@@ -51,6 +102,15 @@ class Smoother:
 
 
 class Mapper:
+    """Translate raw telemetry numbers into normalized (0-1) controller values.
+
+    The ``norm`` argument comes from the YAML config files. Each entry defines a
+    ``min``/``max`` range, an optional ``curve`` (currently only ``"expo"``),
+    and an optional per-parameter ``slew`` value. ``Mapper`` owns a
+    :class:`Smoother` per key and feeds normalized readings through it before
+    handing them off to the MIDI layer.
+    """
+
     def __init__(self, norm: Dict[str, Dict[str, float]]) -> None:
         self._norm = norm
         self._smoothers = {
@@ -58,12 +118,18 @@ class Mapper:
         }
 
     def norm01(self, key: str, value: float) -> float:
+        """Return a smoothed, normalized number in the ``[0, 1]`` range."""
+
         spec = self._norm[key]
         lo, hi = spec["min"], spec["max"]
         rng = hi - lo
+        # Guard against ``min == max`` by falling back to 0.0.
         v = 0.0 if rng == 0 else (value - lo) / rng
         v = clamp(v, 0.0, 1.0)
         if spec.get("curve") == "expo":
+            # Exponential shaping makes the center of the joystick feel more
+            # sensitive while preserving the endpoints. Raise to a power, keep
+            # the sign, then shift back into [0, 1].
             shaped = (abs(v - 0.5) * 2) ** 1.3
             shaped *= 1 if v >= 0.5 else -1
             v = shaped * 0.5 + 0.5
@@ -71,6 +137,14 @@ class Mapper:
 
 
 def read_msp_frame(ser) -> Optional[tuple]:
+    """Read a single MSP frame from ``ser``.
+
+    MSP packets always start with the byte trio ``$M<`` followed by a payload
+    length, command identifier, payload bytes, and a checksum. We ignore the
+    checksum because Betaflight streams fast enough that a corrupt frame can be
+    tossed without fuss.
+    """
+
     if ser.read(1) != b"$" or ser.read(1) != b"M" or ser.read(1) != b"<":
         return None
     size_bytes = ser.read(1)
@@ -85,6 +159,13 @@ def read_msp_frame(ser) -> Optional[tuple]:
 
 
 def build_mapper(norm: Dict[str, Dict[str, float]], overrides: Optional[Dict] = None) -> Mapper:
+    """Create a :class:`Mapper` with configuration overrides applied.
+
+    ``overrides`` mirrors the structure of ``norm`` and allows the CLI wrappers
+    to tweak ranges or slews without editing the base YAML. We merge into a new
+    dictionary to keep the caller's config immutable.
+    """
+
     merged = {key: dict(spec) for key, spec in norm.items()}
     if overrides:
         for key, values in overrides.items():
@@ -93,6 +174,13 @@ def build_mapper(norm: Dict[str, Dict[str, float]], overrides: Optional[Dict] = 
 
 
 def update_state_from_msp(state: Dict[str, float], cmd: int, data: bytes) -> None:
+    """Decode MSP payloads into the ``state`` dictionary.
+
+    Only a handful of MSP commands are relevant for expressive control. This
+    function pattern-matches the command ID, unpacks the payload, and stores the
+    scaled values in-place.
+    """
+
     if cmd == MSP_ATTITUDE and len(data) >= 6:
         roll, pitch, yaw = struct.unpack("<hhh", data[:6])
         state["roll"] = roll / 10.0
@@ -107,6 +195,14 @@ def update_state_from_msp(state: Dict[str, float], cmd: int, data: bytes) -> Non
 
 
 def emit_state_cc(midi_out, mapper: Mapper, channel: int, state: Dict[str, float]) -> None:
+    """Send the current ``state`` over MIDI CC messages.
+
+    Each telemetry field is mapped through the ``Mapper`` and scaled to the
+    canonical MIDI 0-127 range. We also emit a sustain-pedal style gate on CC64
+    to let the patch know when the throttle is live (makes it easy to trigger
+    envelopes or switch scenes).
+    """
+
     for key, control in _CC_MAPPING.items():
         value = int(mapper.norm01(key, state[key]) * 127)
         midi_out.send(
@@ -129,6 +225,19 @@ def run_bridge(
     poll_interval: float = 0.02,
     idle_sleep: float = 0.001,
 ) -> None:
+    """Main pump: read MSP frames and burst out MIDI CC messages.
+
+    Args:
+        serial_port: Path to the serial device emitting MSP telemetry.
+        midi_out: ``mido`` output object; anything with ``send()`` will do.
+        norm: Normalization spec (usually ``config/multi.yaml``'s ``norm`` key).
+        channel: Zero-based MIDI channel number.
+        norm_overrides: Optional nested dict of per-parameter tweaks.
+        stop_event: Optional threading event that can be toggled to exit cleanly.
+        poll_interval: Minimum seconds between MIDI bursts.
+        idle_sleep: Seconds to nap when no MSP frame is available.
+    """
+
     mapper = build_mapper(norm, norm_overrides)
     state = dict(_STATE_TEMPLATE)
     with serial.Serial(serial_port, 115200, timeout=0.01) as ser:  # type: ignore[name-defined]
@@ -138,11 +247,14 @@ def run_bridge(
                 return
             frame = read_msp_frame(ser)
             if frame is None:
+                # No complete frame ready—back off briefly to avoid hogging CPU.
                 time.sleep(idle_sleep)
                 continue
             cmd, data = frame
+            # Fold the new reading into our scratch state buffer.
             update_state_from_msp(state, cmd, data)
             now = time.time()
             if now - last_emit > poll_interval:
+                # Time to publish! Each burst covers every tracked CC.
                 emit_state_cc(midi_out, mapper, channel, state)
                 last_emit = now

--- a/software/midi-bridge/msp_multi_to_midi.py
+++ b/software/midi-bridge/msp_multi_to_midi.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+"""Spin up multiple MSP→MIDI bridges at once.
+
+Where :mod:`msp_to_midi` handles a solo craft, this module is the ensemble
+director. It reads the multi-drone YAML, opens a shared MIDI port, and spawns a
+thread per drone so that every craft gets its own MIDI channel. Comments lean
+into "workbench" mode so students can trace how the concurrency pieces fit
+together.
+"""
+
 import threading
 import time
 from typing import Any, Dict
@@ -15,6 +24,8 @@ def worker(
     midi_out,
     stop_event: threading.Event,
 ) -> None:
+    """Bridge a single drone's MSP stream inside a background thread."""
+
     run_bridge(
         drone["serial"],
         midi_out,
@@ -26,12 +37,15 @@ def worker(
 
 
 def main() -> None:
+    """Load configuration, launch worker threads, and keep them alive."""
+
     with open("config/multi.yaml", "r", encoding="utf-8") as fh:
         cfg = yaml.safe_load(fh)
 
     try:
         midi_out = mido.open_output(cfg["midi"]["port_name"], virtual=True)
     except Exception:
+        # Fallback keeps rehearsals going even if the named port doesn't exist.
         midi_out = mido.open_output()
 
     stop_event = threading.Event()
@@ -47,6 +61,7 @@ def main() -> None:
 
     try:
         while True:
+            # Sleep instead of busy-waiting; the workers do the realtime stuff.
             time.sleep(1)
     except KeyboardInterrupt:
         stop_event.set()

--- a/software/midi-bridge/msp_to_midi.py
+++ b/software/midi-bridge/msp_to_midi.py
@@ -1,5 +1,20 @@
 #!/usr/bin/env python3
-"""CLI wrapper for bridging a single MSP serial stream into MIDI CCs."""
+"""CLI wrapper for bridging a single MSP serial stream into MIDI CCs.
+
+Welcome to the "one drone, one synth voice" entry point. This script is meant
+to be read almost like lab notes—every helper explains why it exists so that
+you can remix it without guessing.
+
+Flow overview:
+
+1. Parse command-line arguments (serial port, MIDI options, scaling configs).
+2. Load the YAML normalization spec and any overrides students want to try.
+3. Open or create a MIDI port using :mod:`mido`.
+4. Delegate to :func:`msp_bridge.run_bridge`, which handles the realtime loop.
+
+If you're teaching or learning from this code, skim the argument parser first;
+it documents every knob you can twist without touching the Python.
+"""
 
 import argparse
 import sys
@@ -12,6 +27,18 @@ from msp_bridge import run_bridge
 
 
 def load_norm(config_path: str, key: Optional[str]) -> Dict[str, Dict[str, float]]:
+    """Load a normalization block from ``config_path``.
+
+    Args:
+        config_path: Path to a YAML file containing either the norm dict itself
+            or a parent mapping with named norm blocks.
+        key: Optional key to select inside the YAML document. ``None`` means the
+            top-level document is already the norm mapping.
+
+    Raises:
+        ValueError: If the document structure doesn't match what we expect.
+    """
+
     with open(config_path, "r", encoding="utf-8") as fh:
         data = yaml.safe_load(fh)
     if key is None:
@@ -28,6 +55,13 @@ def load_norm(config_path: str, key: Optional[str]) -> Dict[str, Dict[str, float
 
 
 def load_overrides(path: Optional[str]) -> Optional[Dict[str, Dict[str, float]]]:
+    """Read optional per-parameter overrides from YAML.
+
+    ``None`` signals "no overrides" which keeps the base config intact. Students
+    can copy-paste the ``norm`` block into a new YAML file and tweak values
+    without touching the shared repo.
+    """
+
     if not path:
         return None
     with open(path, "r", encoding="utf-8") as fh:
@@ -38,6 +72,8 @@ def load_overrides(path: Optional[str]) -> Optional[Dict[str, Dict[str, float]]]
 
 
 def open_midi_output(name: Optional[str], virtual: bool) -> Any:
+    """Open a MIDI output port, falling back to the default port on failure."""
+
     if name:
         try:
             return mido.open_output(name, virtual=virtual)
@@ -47,6 +83,8 @@ def open_midi_output(name: Optional[str], virtual: bool) -> Any:
 
 
 def parse_args() -> argparse.Namespace:
+    """Set up and parse the command-line interface."""
+
     parser = argparse.ArgumentParser(description="Bridge MSP telemetry to MIDI CCs for one craft.")
     parser.add_argument("--serial", required=True, help="Serial port that exposes MSP telemetry")
     parser.add_argument("--channel", type=int, default=1, help="1-based MIDI channel to target (default: 1)")
@@ -90,6 +128,8 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
+    """Parse CLI arguments, load configs, and launch :func:`run_bridge`."""
+
     args = parse_args()
     norm_key = None if args.norm_key == "-" else args.norm_key
     norm = load_norm(args.norm_config, norm_key)
@@ -107,6 +147,7 @@ def main() -> None:
             idle_sleep=args.idle_sleep,
         )
     except KeyboardInterrupt:
+        # Let ctrl+c exit without a stack trace—the performance should stay calm.
         sys.exit(0)
 
 


### PR DESCRIPTION
## Summary
- expand the MSP bridge module with teaching-focused documentation and inline commentary to explain the telemetry to MIDI pipeline
- document the single- and multi-drone launchers so learners understand the CLI flow and concurrency model
- add a README in `software/midi-bridge` that serves as study notes for the bridge scripts

## Testing
- python -m compileall software/midi-bridge

------
https://chatgpt.com/codex/tasks/task_e_68e3c68229b48325b4a2d1dd72a04517