### PR TITLE
Wire CC17 to MSP altitude with throttle fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ This is what you launch when you’re spinning up the full chorus—multiple cra
 
 * * *
 
+## MIDI CC map (play it like an instrument tech)
+| CC | Signal | Notes |
+|---:|---|---|
+| 14 | roll | feeds filters / wavetable scans |
+| 15 | pitch | bends FM depth |
+| 16 | yaw rate | leans into delay feedback |
+| 17 | altitude | comes from `MSP_ALTITUDE`, falls back to a throttle → 0–3 m ramp if the craft ships without a baro |
+| 18 | RSSI | keeps reverb honest |
+| 19 | VBAT | nudges compression / tone |
+| 20 | throttle | classic VCA fuel |
+| 64 | arm gate | sustain-style hold for scene swaps |
+
+The whole mapping is documented like a lab notebook: see
+`docs/CONTROL_STACK_PLAYBOOK.md` for the long-form rationale, smoothing ranges,
+and how to hack on the YAML. The quick headline is that altitude isn't left to
+rot—if `MSP_ALTITUDE` packets arrive we publish meters directly; otherwise we
+lean on throttle so CC17 still animates your patch.
+
+* * *
+
 ## OBS
 Import `obs/DroneChorus_SceneCollection.json`, then relink: **FPV Capture**, **VCV Rack (Window)**, **Program Audio**. Studio Mode recommended.
 

--- a/docs/CONTROL_STACK_PLAYBOOK.md
+++ b/docs/CONTROL_STACK_PLAYBOOK.md
@@ -33,4 +33,5 @@ This is the soup‑to‑nuts wiring for **flight → MIDI → Rack**.
 ## Tuning heuristics
 - **Slew** hides jitter; **expo** on roll/pitch feels musical.
 - Use **yaw rate** for lively micro‑movement; keep delay FB under 0.6.
-- If no baro, map **altitude** to vertical velocity or throttle proxy.
+- Altitude CC: we sniff **MSP_ALTITUDE** first; if the craft never sends it (no
+  baro), the bridge remaps throttle into a 0–3 m envelope so CC17 keeps moving.

--- a/software/midi-bridge/msp_bridge.py
+++ b/software/midi-bridge/msp_bridge.py
@@ -25,7 +25,7 @@ with intent and the data it touches.
 
 import struct
 import time
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 import mido
 import serial
@@ -35,6 +35,7 @@ import serial
 # need; think of them as opcodes that label the payload format.
 MSP_ATTITUDE = 108
 MSP_RC = 105
+MSP_ALTITUDE = 109
 MSP_ANALOG = 110
 
 # A scratch buffer of the telemetry values we track. Each entry represents the
@@ -189,6 +190,9 @@ def update_state_from_msp(state: Dict[str, float], cmd: int, data: bytes) -> Non
         channels = struct.unpack("<8H", data[:16])
         state["throttle"] = channels[2]
         state["yaw"] = (channels[3] - 1500) / 500.0 * 200.0
+    elif cmd == MSP_ALTITUDE and len(data) >= 4:
+        altitude_cm = struct.unpack("<i", data[:4])[0]
+        state["altitude"] = altitude_cm / 100.0
     elif cmd == MSP_ANALOG and len(data) >= 7:
         state["vbat"] = data[0] / 10.0
         state["rssi"] = data[3] if len(data) >= 5 else 100
@@ -224,6 +228,10 @@ def run_bridge(
     stop_event=None,
     poll_interval: float = 0.02,
     idle_sleep: float = 0.001,
+    state_hook: Optional[Callable[[Dict[str, float]], None]] = None,
+    extra_state_handlers: Optional[
+        Dict[int, Callable[[Dict[str, float], bytes], None]]
+    ] = None,
 ) -> None:
     """Main pump: read MSP frames and burst out MIDI CC messages.
 
@@ -236,6 +244,9 @@ def run_bridge(
         stop_event: Optional threading event that can be toggled to exit cleanly.
         poll_interval: Minimum seconds between MIDI bursts.
         idle_sleep: Seconds to nap when no MSP frame is available.
+        state_hook: Optional callback to mutate ``state`` before emitting CCs.
+        extra_state_handlers: Optional MSP command → handler map for decoding
+            telemetry beyond the built-in trio (attitude, RC, analog).
     """
 
     mapper = build_mapper(norm, norm_overrides)
@@ -253,7 +264,11 @@ def run_bridge(
             cmd, data = frame
             # Fold the new reading into our scratch state buffer.
             update_state_from_msp(state, cmd, data)
+            if extra_state_handlers and cmd in extra_state_handlers:
+                extra_state_handlers[cmd](state, data)
             now = time.time()
+            if state_hook is not None:
+                state_hook(state)
             if now - last_emit > poll_interval:
                 # Time to publish! Each burst covers every tracked CC.
                 emit_state_cc(midi_out, mapper, channel, state)

--- a/software/midi-bridge/msp_multi_to_midi.py
+++ b/software/midi-bridge/msp_multi_to_midi.py
@@ -8,6 +8,7 @@ into "workbench" mode so students can trace how the concurrency pieces fit
 together.
 """
 
+import struct
 import threading
 import time
 from typing import Any, Dict
@@ -15,7 +16,7 @@ from typing import Any, Dict
 import mido
 import yaml
 
-from msp_bridge import run_bridge
+from msp_bridge import MSP_ALTITUDE, clamp, run_bridge
 
 
 def worker(
@@ -26,6 +27,36 @@ def worker(
 ) -> None:
     """Bridge a single drone's MSP stream inside a background thread."""
 
+    # Altitude strategy: prefer MSP_ALTITUDE (baro / fusion estimate) and fall back
+    # to a throttle-derived ramp if the craft never publishes barometric data.
+    last_altitude_update = 0.0
+    last_altitude_m = 0.0
+
+    def decode_altitude(state: Dict[str, float], payload: bytes) -> None:
+        """Parse ``MSP_ALTITUDE`` payloads into meters."""
+
+        nonlocal last_altitude_update, last_altitude_m
+        if len(payload) < 4:
+            return
+        altitude_cm = struct.unpack("<i", payload[:4])[0]
+        last_altitude_m = altitude_cm / 100.0
+        state["altitude"] = last_altitude_m
+        last_altitude_update = time.time()
+
+    def inject_altitude(state: Dict[str, float]) -> None:
+        """Ensure ``state['altitude']`` is populated before MIDI scaling."""
+
+        nonlocal last_altitude_update, last_altitude_m
+        now = time.time()
+        if now - last_altitude_update > 1.0:
+            # Baro absent? Treat throttle as an altitude envelope so CC17 still
+            # animates. Normalize to 0..1 then stretch to the 0–3 m map.
+            normalized = (state["throttle"] - 1000.0) / 1000.0
+            normalized = clamp(normalized, 0.0, 1.0)
+            state["altitude"] = normalized * 3.0
+        else:
+            state["altitude"] = last_altitude_m
+
     run_bridge(
         drone["serial"],
         midi_out,
@@ -33,6 +64,8 @@ def worker(
         channel=drone["channel"] - 1,
         norm_overrides=drone.get("norm_overrides"),
         stop_event=stop_event,
+        state_hook=inject_altitude,
+        extra_state_handlers={MSP_ALTITUDE: decode_altitude},
     )
 
 


### PR DESCRIPTION
## Summary
- parse MSP_ALTITUDE frames in the bridge so altitude lives in the shared state
- inject an altitude handler in the multi-bridge that falls back to a throttle-based ramp when baro data is missing
- document the CC17 source and safety net in the playbook and README mapping table

## Testing
- python3 -m compileall software/midi-bridge

------
https://chatgpt.com/codex/tasks/task_e_68e40d62b24c8325b2d0be55f93a0903