### PR TITLE
Add pinned MIDI bridge dependencies

### DIFF
--- a/software/midi-bridge/README.md
+++ b/software/midi-bridge/README.md
@@ -13,6 +13,18 @@ can mangle it into your own rig.
 | `msp_to_midi.py` | Command-line launcher for a single drone. | Shows how to load the YAML norms, open a MIDI port, and kick the bridge loop. |
 | `msp_multi_to_midi.py` | Threaded launcher for multi-drone ensembles. | Demonstrates sharing one MIDI port while isolating each craft on its own channel. |
 
+## Dependencies (keep your rig in tune)
+
+The bridge only leans on three external libraries, all pinned in
+[`requirements.txt`](./requirements.txt) so your bench tests match mine exactly:
+
+- **`mido==1.3.3`** — MIDI plumbing without the mystery smoke.
+- **`PyYAML==6.0.3`** — loads the normalization maps you scribble in `config/`.
+- **`pyserial==3.5`** — keeps the MSP serial link from getting cranky.
+
+Drop into a shell and run `pip install -r software/midi-bridge/requirements.txt`
+before you start hacking; future-you (and your collaborators) will thank you.
+
 ## Study guide
 
 1. **Normalization maps live in `config/multi.yaml`.** The scripts load them and

--- a/software/midi-bridge/requirements.txt
+++ b/software/midi-bridge/requirements.txt
@@ -1,0 +1,3 @@
+mido==1.3.3
+PyYAML==6.0.3
+pyserial==3.5


### PR DESCRIPTION
## Summary
- add a dedicated requirements.txt for the MSP→MIDI bridge and pin the tested dependency versions
- document the dependency expectations in the bridge README so newcomers follow the same stack

## Testing
- pip install -r software/midi-bridge/requirements.txt

------
https://chatgpt.com/codex/tasks/task_e_68e4149d744c8325b4885114dce41e42