### PR TITLE
Add MSP port discovery tips to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ pip install -r software/midi-bridge/requirements.txt
 ```bash
 python3 software/midi-bridge/msp_to_midi.py --serial /dev/ttyUSB0
 ```
+   - Swap `/dev/ttyUSB0` for your actual rig — skim [Find your MSP port](docs/CONTROL_STACK_PLAYBOOK.md#find-your-msp-port) if you need a refresher on sniffing the right device.
    - Default MIDI port: a virtual **DroneChorus** device. Override with `--midi-port MyHardware --no-virtual` if you want to hit a physical DIN box.
    - Reuse the shared scaling map from `config/multi.yaml`; drop a YAML of tweaks via `--norm-overrides path/to/my_overrides.yaml`.
 4) **VCV Rack**: load `vcv/DroneChorus_Patch.vcv`, set the **Core MIDI‑CC** device to **DroneChorus**, Channel 1.

--- a/docs/CONTROL_STACK_PLAYBOOK.md
+++ b/docs/CONTROL_STACK_PLAYBOOK.md
@@ -25,6 +25,12 @@ This is the soup‑to‑nuts wiring for **flight → MIDI → Rack**.
 - Bridge: `software/midi-bridge/msp_to_midi.py --serial <port>` (defaults to a virtual `DroneChorus` MIDI port, channel 1).
 - Rack patch: `vcv/DroneChorus_Patch.vcv` — one voice, prewired attenuverters, easy to duplicate.
 
+## Find your MSP port
+- **Linux**: plug in the quad, then rip `ls /dev/ttyUSB*`. If you see more than one hit, unplug the craft and run it again to spot the disappearing device.
+- **macOS**: same hunt but with Apple flair — `ls /dev/tty.usb*`. Again, yank the cable to confirm which path vanishes.
+- **Windows**: open **Device Manager → Ports (COM & LPT)** and note the COM number (e.g. `COM5`). Prefer CLI? Run `mode` in PowerShell or Command Prompt and scan the list.
+- **Betaflight Configurator**: every time you jack into the quad, hit the **Ports** tab and make sure the correct USB/UART has MSP toggled on. Otherwise the bridge hears nothing and sulks.
+
 ## Multi‑drone (per‑channel)
 - Config: `config/multi.yaml` — list each drone: `serial`, `channel`, optional `norm_overrides`
 - Bridge: `software/midi-bridge/msp_multi_to_midi.py` (spawn via `./scripts/launch_multi.sh` when you want all drones live)


### PR DESCRIPTION
## Summary
- add a "Find your MSP port" section to the control stack playbook covering Linux, macOS, Windows, and Betaflight Configurator checks
- point the single-drone quickstart to the new section so pilots personalize the `--serial` device path

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e5c903d098832592c0d73029af5d83